### PR TITLE
use greadlink in OS X

### DIFF
--- a/acp-java/compile.bash
+++ b/acp-java/compile.bash
@@ -1,9 +1,13 @@
 
+# Find os type. if system`s os is Mac OS X, we use greadlink.
+case "$OSTYPE" in
+  darwin*) DIR=`greadlink -f $0`;;
+  *) DIR=`readlink -f $0`;;
+esac
 
-DIR=`readlink -f $0`
 DIR=`dirname $DIR`
 if test -d "$DIR/../../arcus-java-client" ; then
-  JARFILE=$DIR/../../arcus-java-client/target/arcus-java-client-1.9.0.jar
+  JARFILE=$DIR/../../arcus-java-client/target/arcus-java-client-1.9.5.jar
 else
   if test -d "$DIR/../../java-memcached-client" ; then
     JARFILE=$DIR/../../java-memcached-client/target/arcus-client-1.6.3.0.jar

--- a/acp-java/killandrun.memcached.bash
+++ b/acp-java/killandrun.memcached.bash
@@ -21,7 +21,12 @@ else
   kill_type="$3"
 fi
 
-DIR=`readlink -f $0`
+# Find os type. if system`s os is Mac OS X, we use greadlink.
+case "$OSTYPE" in
+  darwin*) DIR=`greadlink -f $0`;;
+  *) DIR=`readlink -f $0`;;
+esac
+
 DIR=`dirname $DIR`
 MEMC_DIR_NAME=arcus-memcached
 MEMC_DIR=$DIR/../../$MEMC_DIR_NAME

--- a/acp-java/run.bash
+++ b/acp-java/run.bash
@@ -1,8 +1,13 @@
-DIR=`readlink -f $0`
+# Find os type. if system`s os is Mac OS X, we use greadlink.
+case "$OSTYPE" in
+  darwin*) DIR=`greadlink -f $0`;;
+  *) DIR=`readlink -f $0`;;
+esac
+
 DIR=`dirname $DIR`
 if test -d "$DIR/../../arcus-java-client" ; then
   JAR_DIR=$DIR/../../arcus-java-client/target
-  CP=$JAR_DIR/arcus-java-client-1.8.1.jar:$JAR_DIR/zookeeper-3.4.5.jar:$JAR_DIR/log4j-1.2.16.jar:$JAR_DIR/slf4j-api-1.6.1.jar:$JAR_DIR/slf4j-log4j12-1.6.1.jar
+  CP=$JAR_DIR/arcus-java-client-1.9.5.jar:$JAR_DIR/zookeeper-3.4.5.jar:$JAR_DIR/log4j-1.2.16.jar:$JAR_DIR/slf4j-api-1.6.1.jar:$JAR_DIR/slf4j-log4j12-1.6.1.jar
 else
   if test -d "$DIR/../java-memcached-client" ; then
     JAR_DIR=$DIR/../java-memcached-client/target

--- a/acp-java/run.memcached.bash
+++ b/acp-java/run.memcached.bash
@@ -21,7 +21,12 @@ else
   kill_type="$3"
 fi
 
-DIR=`readlink -f $0`
+# Find os type. if system`s os is Mac OS X, we use greadlink.
+case "$OSTYPE" in
+  darwin*) DIR=`greadlink -f $0`;;
+  *) DIR=`readlink -f $0`;;
+esac
+
 DIR=`dirname $DIR`
 MEMC_DIR_NAME=arcus-memcached
 MEMC_DIR=$DIR/../../$MEMC_DIR_NAME

--- a/acp-java/setup-test-zk.bash
+++ b/acp-java/setup-test-zk.bash
@@ -1,4 +1,9 @@
-DIR=`readlink -f $0`
+# Find os type. if system`s os is Mac OS X, we use greadlink.
+case "$OSTYPE" in
+  darwin*) DIR=`greadlink -f $0`;;
+  *) DIR=`readlink -f $0`;;
+esac
+
 DIR=`dirname $DIR`
 
 ZK_CLI="$DIR/../../arcus/zookeeper/bin/zkCli.sh"


### PR DESCRIPTION
OS X 관련 PR입니다.
readlink 대신 greadlink를 사용하기 때문에,
darwin OSTYPE일 경우 greadlink를 사용하도록 변경했습니다.

추가로, JARFILE  version을 최신 arcus-java-client 버전인 1.9.5로 변경했습니다.
