### PR TITLE
CLEANUP: keyset roop test

### DIFF
--- a/acp-java/acp.java
+++ b/acp-java/acp.java
@@ -80,13 +80,20 @@ class acp {
   public void setup() throws Exception {
     // Key profile
     keyset kset = null;
+    boolean useKeyRoop = true;
+    if (conf.time < 0) {
+      useKeyRoop = false;
+      conf.time = 0;
+    }
+
     if (conf.keyset_profile.equals("default")) {
-      kset = new keyset_default(conf.keyset_size, conf.key_prefix);
+      kset = new keyset_default(conf.keyset_size, conf.key_prefix, useKeyRoop);
     }
     else if (conf.keyset_profile.equals("numeric")) {
       kset = new keyset_numeric(conf.keyset_size, conf.keyset_length,
-                                conf.key_prefix);
+                                conf.key_prefix, useKeyRoop);
     }
+
     if (kset == null) {
       System.out.println("Cannot find keyset profile=" + conf.keyset_profile);
       System.exit(0);

--- a/acp-java/integration/run_integration_idc.pl
+++ b/acp-java/integration/run_integration_idc.pl
@@ -93,7 +93,7 @@ if ($mode == 2) {
       "client=10\n" .
       "rate=0\n" .
       "request=0\n" .
-      "time=$run_time\n" .
+      "time=-1\n" .
       "keyset_size=$keyset_size\n" .
       "valueset_min_size=10\n" .
       "valueset_max_size=30\n" .
@@ -136,7 +136,7 @@ if ($mode == 3) {
       "client=100\n" .
       "rate=0\n" .
       "request=0\n" .
-      "time=$run_time\n" .
+      "time=-1\n" .
       "keyset_size=$keyset_size\n" .
       "valueset_min_size=10\n" .
       "valueset_max_size=30\n" .

--- a/acp-java/integration/run_integration_idc_func.pl
+++ b/acp-java/integration/run_integration_idc_func.pl
@@ -121,7 +121,7 @@ print CONF
     "client=32\n" .
     "rate=0\n" .
     "request=0\n" .
-    "time=$run_time\n" .
+    "time=-1\n" .
     "keyset_size=$keyset_size\n" .
     "valueset_min_size=10\n" .
     "valueset_max_size=30\n" .
@@ -159,7 +159,7 @@ print CONF
     "client=32\n" .
     "rate=0\n" .
     "request=0\n" .
-    "time=$run_time\n" .
+    "time=-1\n" .
     "keyset_size=$keyset_size\n" .
     "valueset_min_size=10\n" .
     "valueset_max_size=30\n" .

--- a/acp-java/integration/run_integration_rangesearch.pl
+++ b/acp-java/integration/run_integration_rangesearch.pl
@@ -45,7 +45,7 @@ foreach $script (@script_list) {
         "client=1\n" .
         "rate=0\n" .
         "request=0\n" .
-        "time=6000000\n" .
+        "time=-1\n" .
         "keyset_size=10000\n" .
         "valueset_min_size=20\n" .
         "valueset_max_size=20\n" .

--- a/acp-java/integration/run_integration_repl_func.pl
+++ b/acp-java/integration/run_integration_repl_func.pl
@@ -118,7 +118,7 @@ if ($flag eq -1 || $flag eq 1) {
       #"single_server=" . $zk_ip . ":" . $t_port . "\n" .
       "client=100\n" .
       "rate=400\n" .
-      "request=0\n" .
+      "request=-1\n" .
       "time=$run_time\n" .
       "keyset_size=$keyset_size\n" .
       "valueset_min_size=10\n" .

--- a/acp-java/integration/run_integration_repl_switchover.pl
+++ b/acp-java/integration/run_integration_repl_switchover.pl
@@ -60,7 +60,7 @@ print CONF
     "client=10\n" .
     "rate=1000\n" .
     "request=0\n" .
-    "time=600\n" .
+    "time=-1\n" .
     "keyset_size=$keyset_size\n" .
     "valueset_min_size=10\n" .
     "valueset_max_size=30\n" .

--- a/acp-java/integration_idc_onlyget.java
+++ b/acp-java/integration_idc_onlyget.java
@@ -44,41 +44,41 @@ public class integration_idc_onlyget implements client_profile {
     String key;
     byte[] val = null;
 
-    if (!cli.ks.keyset_store()) {
-      if (!cli.before_request())
-        return false;
-      key = cli.ks.get_key();
-      do {
-        try {
-          Future<byte[]> f = cli.next_ac.asyncGet(key, raw_transcoder.raw_tc);
-          val = f.get(cli.conf.client_timeout, TimeUnit.MILLISECONDS);
-          if (val == null) {
-              System.out.printf("idc onlyget test faile key miss : %s\n",key);
-              System.exit(1);
-          }
-          if (!cli.write_operation(key, val)) {
-            System.out.printf("idc onlyget test failed : file write occur exception.");
-            System.exit(1);
-          }
-        } catch (net.spy.memcached.internal.CheckedOperationTimeoutException te) {
-            if (get_try-- > 0) {
-                System.out.printf("idc get failed. id=%d key=%s remain try count : %d\n",cli.id, key, get_try);
-                Thread.sleep(1000);
-            } else {
-                System.out.printf("idc get failed. id=%d key=%s get operation exceeded 10 times\n",cli.id, key);
-                System.exit(1);
-            }
-        } catch (Exception e) {
-            System.out.printf("idc get failed. id=%d key=%s\n",cli.id);
-            e.printStackTrace();
-            System.exit(1);
-        }
-      } while (val == null);
-      if (!cli.after_request(true))
-        return false;
-    } else {
-        cli.set_stop(true);
+    key = cli.ks.get_key();
+    if (key == null) {
+      cli.set_stop(true);
+      return true;
     }
+    if (!cli.before_request())
+      return false;
+    do {
+      try {
+        Future<byte[]> f = cli.next_ac.asyncGet(key, raw_transcoder.raw_tc);
+        val = f.get(cli.conf.client_timeout, TimeUnit.MILLISECONDS);
+        if (val == null) {
+          System.out.printf("idc onlyget test faile key miss : %s\n",key);
+          System.exit(1);
+        }
+        if (!cli.write_operation(key, val)) {
+          System.out.printf("idc onlyget test failed : file write occur exception.");
+          System.exit(1);
+        }
+      } catch (net.spy.memcached.internal.CheckedOperationTimeoutException te) {
+        if (get_try-- > 0) {
+          System.out.printf("idc get failed. id=%d key=%s remain try count : %d\n",cli.id, key, get_try);
+          Thread.sleep(1000);
+        } else {
+          System.out.printf("idc get failed. id=%d key=%s get operation exceeded 10 times\n",cli.id, key);
+          System.exit(1);
+        }
+      } catch (Exception e) {
+        System.out.printf("idc get failed. id=%d key=%s\n",cli.id);
+        e.printStackTrace();
+        System.exit(1);
+      }
+    } while (val == null);
+    if (!cli.after_request(true))
+      return false;
 
     return true;
   }

--- a/acp-java/integration_idc_onlyset.java
+++ b/acp-java/integration_idc_onlyset.java
@@ -45,35 +45,35 @@ public class integration_idc_onlyset implements client_profile {
     Future<Boolean> fb;
     boolean ok = false;
     int tries = 10;
-    if (!cli.ks.keyset_store()) {
-      if (!cli.before_request())
-        return false;
-      key = cli.ks.get_key();
-      val = cli.vset.get_value();
-      do {
-        try {
-          fb = cli.next_ac.set(key, cli.conf.client_exptime, val, raw_transcoder.raw_tc);
-          ok = fb.get(cli.conf.client_timeout, TimeUnit.MILLISECONDS);
-          if (!cli.write_operation(key, val)) {
-            System.out.println("idc onlyset test failed : file write occur exception.");
-            System.exit(1);
-          }
-        } catch (net.spy.memcached.internal.CheckedOperationTimeoutException te) {
-          if (tries-- <= 0) {
-            System.out.println("test failed operationtimeout over 10 times");
-            System.exit(1);
-          }
-          System.out.println("this test should not occur with TimeoutException... retry set key : " + key);
-        } catch (Exception e) {
-          System.out.println("retry set operation after 1 seconds");
-          Thread.sleep(1000);
-        }
-      } while (!ok);
-      if (!cli.after_request(ok))
-        return false;
-    } else {
-        cli.set_stop(true);
+    key = cli.ks.get_key();
+    if (key == null) {
+      cli.set_stop(true);
+      return true;
     }
+    if (!cli.before_request())
+      return false;
+    val = cli.vset.get_value();
+    do {
+      try {
+        fb = cli.next_ac.set(key, cli.conf.client_exptime, val, raw_transcoder.raw_tc);
+        ok = fb.get(cli.conf.client_timeout, TimeUnit.MILLISECONDS);
+        if (!cli.write_operation(key, val)) {
+          System.out.println("idc onlyset test failed : file write occur exception.");
+          System.exit(1);
+        }
+      } catch (net.spy.memcached.internal.CheckedOperationTimeoutException te) {
+        if (tries-- <= 0) {
+          System.out.println("test failed operationtimeout over 10 times");
+          System.exit(1);
+        }
+        System.out.println("this test should not occur with TimeoutException... retry set key : " + key);
+      } catch (Exception e) {
+        System.out.println("retry set operation after 1 seconds");
+        Thread.sleep(1000);
+      }
+    } while (!ok);
+    if (!cli.after_request(ok))
+      return false;
     return true;
   }
 }

--- a/acp-java/integration_onlyset.java
+++ b/acp-java/integration_onlyset.java
@@ -45,31 +45,31 @@ public class integration_onlyset implements client_profile {
     Future<Boolean> fb;
     boolean ok = false;
     int tries = 10;
-    if (!cli.ks.keyset_store()) {
-      if (!cli.before_request())
-        return false;
-      key = cli.ks.get_key();
-      val = cli.vset.get_value();
-      do {
-        try {
-          fb = cli.next_ac.set(key, cli.conf.client_exptime, val, raw_transcoder.raw_tc);
-          ok = fb.get(cli.conf.client_timeout, TimeUnit.MILLISECONDS);
-        } catch (net.spy.memcached.internal.CheckedOperationTimeoutException te) {
-          if (tries-- <= 0) {
-            System.out.println("test failed operationtimeout over 10 times");
-            System.exit(1);
-          }
-          System.out.println("this test should not occur with TimeoutException... retry set key : " + key);
-        } catch (Exception e) {
-          System.out.println("retry set operation after 1 seconds");
-          Thread.sleep(1000);
-        }
-      } while (!ok);
-      if (!cli.after_request(ok))
-        return false;
-    } else {
-        cli.set_stop(true);
+    if (!cli.before_request())
+      return false;
+    key = cli.ks.get_key();
+    if (key == null) {
+      cli.set_stop(true);
+      return true;
     }
+    val = cli.vset.get_value();
+    do {
+      try {
+        fb = cli.next_ac.set(key, cli.conf.client_exptime, val, raw_transcoder.raw_tc);
+        ok = fb.get(cli.conf.client_timeout, TimeUnit.MILLISECONDS);
+      } catch (net.spy.memcached.internal.CheckedOperationTimeoutException te) {
+        if (tries-- <= 0) {
+          System.out.println("test failed operationtimeout over 10 times");
+          System.exit(1);
+        }
+        System.out.println("this test should not occur with TimeoutException... retry set key : " + key);
+      } catch (Exception e) {
+        System.out.println("retry set operation after 1 seconds");
+        Thread.sleep(1000);
+      }
+    } while (!ok);
+    if (!cli.after_request(ok))
+      return false;
     return true;
   }
 }

--- a/acp-java/integration_rangesearch.java
+++ b/acp-java/integration_rangesearch.java
@@ -48,10 +48,10 @@ public class integration_rangesearch implements client_profile {
     CollectionFuture<List<Object>> fl;
     OperationStatus status;
 
-    if (!cli.ks.keyset_store()) {
+    key = cli.ks.get_key();
+    if (key != null) {
       if (!cli.before_request())
         return false;
-      key = cli.ks.get_key();
       val = cli.vset.get_value();
       fb = cli.next_ac.set(key, cli.conf.client_exptime, val, raw_transcoder.raw_tc);
       ok = fb.get(cli.conf.client_timeout, TimeUnit.MILLISECONDS);
@@ -100,7 +100,6 @@ public class integration_rangesearch implements client_profile {
       }
       cli.set_stop(true);
     }
-
 
     return true;
   }

--- a/acp-java/integration_repltest.java
+++ b/acp-java/integration_repltest.java
@@ -44,10 +44,10 @@ public class integration_repltest implements client_profile {
     boolean ok = false;
 
     // set as many keys as cli.conf.keyset_size
-    if (!cli.ks.keyset_store()) {
+    key = cli.ks.get_key();
+    if (key != null) {
       if (!cli.before_request())
         return false;
-      key = cli.ks.get_key();
       val = cli.vset.get_value();
       do {
         try {

--- a/acp-java/keyset.java
+++ b/acp-java/keyset.java
@@ -19,5 +19,4 @@ interface keyset {
   public void reset();
   public String get_key();
   public String get_key_by_cliid(client cli); // for recovery test
-  public boolean keyset_store();
 }

--- a/acp-java/keyset_default.java
+++ b/acp-java/keyset_default.java
@@ -21,10 +21,10 @@ class keyset_default implements keyset {
   String[] set;
   int next_idx;
   // for integration test
-  boolean keyset_store;
   int offset;
+  boolean useKeyRoop;
 
-  public keyset_default(int num, String prefix) {
+  public keyset_default(int num, String prefix, boolean useKeyRoop) {
     set = new String[num];
     for (int i = 0; i < num; i++) {
       set[i] = "testkey-" + i;
@@ -32,12 +32,12 @@ class keyset_default implements keyset {
         set[i] = prefix + set[i];
     }
     this.offset = 0;
+    this.useKeyRoop = useKeyRoop;
     reset();
   }
 
   public void reset() {
     next_idx = 0;
-    keyset_store = false;
   }
 
   public String get_key_by_cliid(client cli) {
@@ -49,13 +49,12 @@ class keyset_default implements keyset {
   synchronized public String get_key() {
     int idx = next_idx++;
     if (next_idx >= set.length) {
-      keyset_store = true;
-      next_idx = 0;
+      if (useKeyRoop) {
+        next_idx = 0;
+      } else {
+        return null;
+      }
     }
     return set[idx];
-  }
-
-  synchronized public boolean keyset_store() {
-      return keyset_store;
   }
 }

--- a/acp-java/keyset_numeric.java
+++ b/acp-java/keyset_numeric.java
@@ -20,11 +20,12 @@
 class keyset_numeric implements keyset {
   String[] set;
   int next_idx;
+  boolean useKeyRoop;
 
   // Each key is simply base-10 integer in ASCII.
   // Each has 'len' digits.
 
-  public keyset_numeric(int num, int len, String prefix) {
+  public keyset_numeric(int num, int len, String prefix, boolean useKeyRoop) {
     set = new String[num];
     char[] c = new char[len];
     for (int i = 0; i < num; i++) {
@@ -37,6 +38,7 @@ class keyset_numeric implements keyset {
       if (prefix != null)
         set[i] = prefix + set[i];
     }
+    this.useKeyRoop = useKeyRoop;
     reset();
   }
 
@@ -50,12 +52,13 @@ class keyset_numeric implements keyset {
 
   synchronized public String get_key() {
     int idx = next_idx++;
-    if (next_idx >= set.length)
-      next_idx = 0;
+    if (next_idx >= set.length) {
+      if (useKeyRoop) {
+        next_idx = 0;
+      } else {
+        return null;
+      }
+    }
     return set[idx];
-  }
-
-  public boolean keyset_store() {
-    return false;
   }
 }


### PR DESCRIPTION
한정된 key만을 사용하는 테스트들에서 간헐적으로 1개의 key를 더 사용하는 버그가 발생하고 있습니다.
이를 해결한 PR입니다.
idc와 stash를 포함하여 rangesearch, switchover에도 영향을 미치기 때문에 PR처리합니다.
확인부탁드립니다.