### PR TITLE
FIX: Fix sum of total_retrans.

### DIFF
--- a/mrr/mrr.c
+++ b/mrr/mrr.c
@@ -152,7 +152,7 @@ checker_remove_so(int so)
   for (i = 0; i < CHECK_MAX_SO; i++) {
     if (checker_so[i] >= 0)
       checker_so[checker_so_num++] = checker_so[i];
-  }  
+  }
   pthread_mutex_unlock(&checker_lock);
 }
 
@@ -162,6 +162,7 @@ check_thread(void *arg)
   /* Do nother with locking */
   while (1) {
     usleep(100);
+    uint32_t temp_total_retrans = 0;
     int i;
     for (i = 0; i < checker_so_num; i++) {
       int so = checker_so[i];
@@ -182,8 +183,9 @@ check_thread(void *arg)
         max_retransmits = info.tcpi_retransmits;
       if (max_backoff == 0 || max_backoff < info.tcpi_backoff)
         max_backoff = info.tcpi_backoff;
-      total_retrans += info.tcpi_total_retrans;
+      temp_total_retrans += info.tcpi_total_retrans;
     }
+    total_retrans = temp_total_retrans;
   }
   return NULL;
 }
@@ -272,7 +274,7 @@ rr_thread(void *arg)
             goto exit;
           }
         }
-      }      
+      }
       s = write(r->so, r->buf, msg_len);
       if (s != msg_len) {
         log_msg("%d: write failed. s=%d msg_len=%d error=%s(%d). stopping\n",
@@ -289,7 +291,7 @@ rr_thread(void *arg)
       char *buf;
 
       // Sleep a little and then send a request and receive a response
-      
+
       if (r->sleep > 0)
         usleep(r->sleep);
 
@@ -323,9 +325,9 @@ rr_thread(void *arg)
       hist_inc(&r->hist, (uint32_t)msec);
     }
   }
-  
+
 exit:
-  
+
 #if CHECK_RTO_RETRANS
   checker_remove_so(r->so);
 #endif
@@ -380,13 +382,13 @@ main(int argc, char *argv[])
       pthread_create(&tid, &attr, stat_thread, NULL);
   }
 #endif
-  
+
   if (args_s) {
     int one = 1;
     int new_conn;
     int id = 0;
     struct rr *r;
-    
+
     so = socket(AF_INET, SOCK_STREAM, 0);
     if (so < 0) {
       PERROR_DIE("socket");
@@ -402,7 +404,7 @@ main(int argc, char *argv[])
     }
     while ((new_conn = accept(so, NULL, NULL)) > 0) {
       log_msg("server accepted a conn. so=%d id=%d\n", new_conn, id);
-      
+
       r = malloc(sizeof(*r));
       memset(r, 0, sizeof(*r));
       r->id = id++;
@@ -419,7 +421,7 @@ main(int argc, char *argv[])
     int i;
     struct hist prev_hist, cur_hist;
     uint32_t prev_count, cur_count;
-    
+
     ra = malloc(sizeof(*ra) * args_t);
     memset(ra, 0, sizeof(*ra) * args_t);
     for (i = 0; i < args_t; i++) {
@@ -432,7 +434,7 @@ main(int argc, char *argv[])
       }
 
       log_msg("connected to server. so=%d id=%d\n", so, i);
-      
+
       r = &ra[i];
       r->id = i;
       r->so = so;
@@ -442,13 +444,13 @@ main(int argc, char *argv[])
       pthread_attr_setscope(&r->attr, PTHREAD_SCOPE_SYSTEM);
       pthread_create(&r->tid, &r->attr, rr_thread, r);
     }
-    
+
     // Print stats forever
     memset(&prev_hist, 0, sizeof(prev_hist));
     prev_count = 0;
     while (1) {
       sleep(1);
-      
+
       // Gather stats from threads
       memset(&cur_hist, 0, sizeof(cur_hist));
       cur_count = 0;
@@ -474,7 +476,7 @@ main(int argc, char *argv[])
 #endif
     }
   }
-  
+
   return 0;
 }
 
@@ -484,7 +486,7 @@ log_msg(const char *fmt, ...)
   time_t t;
   struct tm tm;
   va_list ap;
-  
+
   t = time(NULL);
   localtime_r(&t, &tm);
   printf("[%04d/%02d/%02d-%02d:%02d:%02d] ",
@@ -510,7 +512,7 @@ filladdr(char *host, struct sockaddr_in *addr)
     if (sizeof(struct in_addr) != h->h_length) {
       ERROR_DIE("h_length");
     }
-    
+
     addr->sin_family = AF_INET;
     addr->sin_addr.s_addr = *((uint32_t*)h->h_addr_list[0]);
   }


### PR DESCRIPTION
total_retrans 수치가 비정상적으로 집계되는 현상을 수정했습니다.
불필요한 White Space가 사라진 것은 Visual Studio Code 설정에 의한 것입니다.

# AS-IS
1. 100us 마다 각 TCP Connection에 대한 total_retrans 값의 합계를 구함
2. **1의 값을 전역 변수에 더함**
3. 1초마다 2의 전역 변수 값을 출력한 뒤 0으로 초기화

## 예시
- 10개의 TCP Connection에 각각 total_retrans 값이 1이라면
- 각 TCP Connection에 대한 total_retrans 값의 합계는 10
- 10을 100us 마다 전역 변수에 더함
- 1초마다 전역 변수를 출력하므로, (1 second / 100us) = 1만번 집계되어 (1만 * 10) = 10만의 값이 출력됨

# TO-BE
1. 100us 마다 각 TCP Connection에 대한 total_retrans 값의 합계를 구함
2. **1의 값을 전역 변수에 대입**
3. 1초마다 2의 전역 변수 값을 출력

## 예시

- 10개의 TCP Connection에 각각 total_retrans 값이 1이라면
- 각 TCP Connection에 대한 total_retrans 값의 합계는 10
- 10을 100us 마다 전역 변수에 대입
- 1초마다 전역 변수 출력하지만, 더하는 것이 아니라 대입하는 것이므로 10의 값이 출력됨